### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # HideComments
 HideComments plugin for Vanilla Forums
+
 v1.1.0
 
 Allows for users to hide specific comments within a discussion. The hide preference is saved and subsequent views will show a collapsed comment that can be expanded again.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
-# HideComments
-HideComments plugin for Vanilla Forums
+HideComments
+============
 
-v1.0.1
+HideComments plugin for Vanilla Forums 
+
+*Version* 1.0.1
 
 Allows for users to hide specific comments within a discussion. The hide preference is saved and subsequent views will show a collapsed comment that can be expanded again.
 
-Change Log:
-1.0.0 - Initial Release
-1.0.1 - Added NO_HIDE_ROLES and checks for them, so users can't hide Administrators and Moderators
+*Change Log*
+*1.0.0 - _Initial Release_
+*1.0.1 - _Added checks for roles_
 
-Version 1.0.1 Note:
+Version 1.0.1 Note
+------------------
 By default, this plugin will not let users hide comments from Moderators and Administrators. To override this, place this line in your config.php:
-
-`$Configuration['Plugins']['HideComments']['NoHideRoles'] = 'A,comma,separated,list';`
-
+```
+$Configuration['Plugins']['HideComments']['NoHideRoles'] = 'A,comma,separated,list';
+```
 Use role names as they are defined in your forum configuration.
 
 
-Developed on Vanilla Forums 2.1.9
+*Developed on Vanilla Forums 2.1.9*
 
-Side Note: This is my first plugin. I welcome feedback! If you feel I've done something wrong or could do something better, please let me know!
+I welcome any feedback!
 
-This plugin is released under GPL v2. See header for more information.
+_This plugin is released under GPL v2. See header for more information._

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 HideComments
 ============
 
-HideComments plugin for Vanilla Forums 
-
+HideComments plugin for Vanilla Forums  
 *Version* 1.0.1
 
 Allows for users to hide specific comments within a discussion. The hide preference is saved and subsequent views will show a collapsed comment that can be expanded again.
 
-*Change Log*
-*1.0.0 - _Initial Release_
-*1.0.1 - _Added checks for roles_
+*Change Log*  
+* 1.0.0 - _Initial Release_  
+* 1.0.1 - _Added checks for roles_
 
-Version 1.0.1 Note
-------------------
+*Version 1.0.1 Note*  
 By default, this plugin will not let users hide comments from Moderators and Administrators. To override this, place this line in your config.php:
 ```
 $Configuration['Plugins']['HideComments']['NoHideRoles'] = 'A,comma,separated,list';
 ```
 Use role names as they are defined in your forum configuration.
 
+---
 
 *Developed on Vanilla Forums 2.1.9*
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # HideComments
 HideComments plugin for Vanilla Forums
+v1.1.0
 
 Allows for users to hide specific comments within a discussion. The hide preference is saved and subsequent views will show a collapsed comment that can be expanded again.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # HideComments
 HideComments plugin for Vanilla Forums
 
-v1.1.0
+v1.0.1
 
 Allows for users to hide specific comments within a discussion. The hide preference is saved and subsequent views will show a collapsed comment that can be expanded again.
+
+Change Log:
+1.0.0 - Initial Release
+1.0.1 - Added NO_HIDE_ROLES and checks for them, so users can't hide Administrators and Moderators
+
+Version 1.0.1 Note:
+By default, this plugin will not let users hide comments from Moderators and Administrators. To override this, place this line in your config.php:
+
+`$Configuration['Plugins']['HideComments']['NoHideRoles'] = 'A,comma,separated,list';`
+
+Use role names as they are defined in your forum configuration.
+
 
 Developed on Vanilla Forums 2.1.9
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@ HideComments
 ============
 
 HideComments plugin for Vanilla Forums  
-*Version* 1.0.1
+Version: 1.0.1
 
 Allows for users to hide specific comments within a discussion. The hide preference is saved and subsequent views will show a collapsed comment that can be expanded again.
 
-*Change Log*  
+**Change Log**  
 * 1.0.0 - _Initial Release_  
 * 1.0.1 - _Added checks for roles_
 
-*Version 1.0.1 Note*  
+**Version 1.0.1 Note**  
 By default, this plugin will not let users hide comments from Moderators and Administrators. To override this, place this line in your config.php:
 ```
 $Configuration['Plugins']['HideComments']['NoHideRoles'] = 'A,comma,separated,list';
@@ -19,7 +19,8 @@ Use role names as they are defined in your forum configuration.
 
 ---
 
-*Developed on Vanilla Forums 2.1.9*
+**Developed on Vanilla Forums 2.1.9**  
+May work on earlier versions, but they have not been tested.
 
 I welcome any feedback!
 

--- a/class.hidecomments.plugin.php
+++ b/class.hidecomments.plugin.php
@@ -9,7 +9,7 @@
  * 
  * With techniques borrowed from the Ignore plugin by Tim Gunter.
  *
- * @version 1.0.0
+ * @version 1.1.0
  * @author Jonathan Walker <xorith@gmail.com>
  * @copyright 2015 Jonathan Walker
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
@@ -20,7 +20,7 @@
 $PluginInfo['HideComments'] = array(
    'Name'                  => 'Hide Comments',
    'Description'           => 'Allows users to hide comments within a discussion.',
-   'Version'               => '1.0.0',
+   'Version'               => '1.1.0',
    'RequiredApplications'  => FALSE,
    'RequiredTheme'         => FALSE, 
    'RequiredPlugins'       => FALSE,


### PR DESCRIPTION
Added checks for roles and a config.php option to define what roles to check against. Users cannot hide comments from other users with those roles. By default, this plugin checks for Administrator and Moderator.

Also learned more MD and made the README file better.
